### PR TITLE
Remove the Kotlin JRE ST LIB from dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,12 @@ publishing {
                         dep.name == it.artifactId.text()
                     }
                 }.each() {
+
+                    // explicitly remove the kotlin jre requirement
+                    if (it.artifactId.text() == 'kotlin-stdlib-jre8') {
+                        it.parent().remove(it)
+                    }
+
                     it.scope*.value = 'compile'
                 }
             }


### PR DESCRIPTION
When this gets published, we included "kotlin-stdlib-jre8".  I don't
think this is needed to call it, so I'm going to explicitly remove it
when building the POM