### PR TITLE
Revert "Remove the Kotlin JRE ST LIB from dependencies"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,12 +72,6 @@ publishing {
                         dep.name == it.artifactId.text()
                     }
                 }.each() {
-
-                    // explicitly remove the kotlin jre requirement
-                    if (it.artifactId.text() == 'kotlin-stdlib-jre8') {
-                        it.parent().remove(it)
-                    }
-
                     it.scope*.value = 'compile'
                 }
             }


### PR DESCRIPTION
Reverts fod-dev/bsi-token-parser#10

Missing the kotlin jre runtime dependency will not cause compile time errors, but will crash upon execution when running as a java dependency.