### PR TITLE
Downgrading kotlin version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id 'org.jetbrains.dokka' version '1.4.30'
-    id 'org.jetbrains.kotlin.jvm' version '1.4.31'
+    id 'org.jetbrains.dokka' version '1.4.32'
+    id 'org.jetbrains.kotlin.jvm' version '1.3.41'
     id 'maven-publish'
     id 'signing'
     id 'io.github.gradle-nexus.publish-plugin' version '1.0.0'
@@ -13,7 +13,7 @@ description 'Fortify BSI Token Parser library'
 sourceCompatibility = 1.8
 
 ext {
-    kotlin_version = "1.4.31"
+    kotlin_version = "1.3.72"
     spek_version = "2.0.10"
 }
 
@@ -23,7 +23,7 @@ repositories {
 }
 
 dependencies {
-    compile "org.apache.httpcomponents:httpclient:4.5.2"
+    compile "org.apache.httpcomponents:httpclient:4.5.13"
     compile "com.beust:klaxon:5.5"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     // assertion


### PR DESCRIPTION
We can't use any of the 1.4.x versions of kotlin because they do not support java8, and our library is targeted to work under java8 at the moment