### PR TITLE
Downgrading klaxon to maintain java8 compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ description 'Fortify BSI Token Parser library'
 sourceCompatibility = 1.8
 
 ext {
-    kotlin_version = "1.3.72"
+    kotlin_version = "1.3.70"
     spek_version = "2.0.10"
 }
 
@@ -23,8 +23,8 @@ repositories {
 }
 
 dependencies {
-    compile "org.apache.httpcomponents:httpclient:4.5.13"
-    compile "com.beust:klaxon:5.5"
+    compile "org.apache.httpcomponents:httpclient:4.5.3"
+    compile "com.beust:klaxon:5.4"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     // assertion
     testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlin_version"


### PR DESCRIPTION
klaxon of version 5.5 has upgraded the dependency to kotlin-stdlib and kotlin-reflect to 1.4.31 and that broke compatibility with java8 runtime. Downgrading all kotlin library versions to 1.3.70 to maintain compatibility.